### PR TITLE
Make sure to set the object datatype if there is one. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,8 @@ function levelgraphJSONLD(db, jsonldOpts) {
               }
             } else if(triple.object.datatype.match(RDFLANGSTRING)){
               node.value = '"' + triple.object.value + '"@' + triple.object.language;
+            } else {
+              node.value = '"' + triple.object.value + '"^^' + triple.object.datatype;
             }
           }
           acc[key] = node.value;

--- a/test/datatype_spec.js
+++ b/test/datatype_spec.js
@@ -152,6 +152,29 @@ describe('jsonld.put data type', function() {
 
       });
     });
+
+    it('does preserve custom type when defined for given object', function(done) {
+      var example = {
+        "@context": {
+          "@vocab": "http://example.com/"
+        },
+        "@id": "http://example.com/123",
+        "password": {
+          "@value": "foo",
+          "@type": "http://example.com/#password"
+        }
+      };
+      db.jsonld.put(example, function() {
+        db.get({
+          predicate: 'http://example.com/password'
+        }, function(err, triples) {
+          expect(triples[0].object).to.equal('"foo"^^http://example.com/#password');
+          done();
+        });
+
+      });
+    });
+
   });
 });
 describe('jsonld.get data type', function() {


### PR DESCRIPTION
Make sure to set the object datatype if there is one. Otherwise the object will be thought to be an URI.

{
  "@context": {
    "@vocab": "http://example.com/"
  },

  "password": {
    "@value": "foo",
    "@type": "http://example.com/#password"
  }

}

... so you would incorrectly get "password": {"@id": "foo"} when getting it from the database later.