### PR TITLE
React to error in doPut, e.g. something not permitted in JSON-LD

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,9 @@ function levelgraphJSONLD(db, jsonldOpts) {
     var blanks = {};
 
     jsonld.toRDF(obj, options, function(err, triples) {
+      if (err || triples.length === 0) {
+        return callback(err, null);
+      }
 
       var stream = graphdb.putStream();
 

--- a/test/put_spec.js
+++ b/test/put_spec.js
@@ -170,6 +170,18 @@ describe('jsonld.put', function() {
       });
     });
   });
+
+  it('should receive error on invalid input', function(done) {
+    var invalid = {
+      "@context": { "@vocab": "http//example.com/" },
+      "test": { "@value": "foo", "bar": "oh yes" }
+    }
+    db.jsonld.put(invalid, function(err) {
+      expect(err && err.name).to.equal('jsonld.RdfError');
+      expect(err && err.message).to.equal('Could not expand input before serialization to RDF.');
+      done();
+    });
+  });
 });
 
 describe('jsonld.put with default base', function() {


### PR DESCRIPTION
React to error in doPut, e.g. something not permitted in JSON-LD.

In case there's an error in the JSON-LD data processing we should not try
to go on. The error can be easily reproduced trying to insert data like

{
  "test": { "@value": "foo", "invalidproperty": true }
}