### PR TITLE
In the fetchExpandedTriples callback, if expanded wasn't found for some reason, don't blow up.

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,9 +207,9 @@ function levelgraphJSONLD(db, jsonldOpts) {
           cb(null, acc);
         } else {
           fetchExpandedTriples(triple.object, function(err, expanded) {
-            if (!acc[triple.subject][triple.predicate]) {
+            if (expanded !== null && !acc[triple.subject][triple.predicate]) {
               acc[triple.subject][triple.predicate] = expanded[triple.object];
-            } else {
+            } else if (expanded !== null) {
               if (!acc[triple.subject][triple.predicate].push) {
                 acc[triple.subject][triple.predicate] = [acc[triple.subject][triple.predicate]];
               }


### PR DESCRIPTION
In the fetchExpandedTriples callback, if expanded wasn't found for some reason, don't blow up.

I'm not sure why expanded wasn't found, but that did happen to me and this seems like the reasonable thing to do when in such cases.

