### PR TITLE
fixed broken dependency to levelgraph in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "n3": "~0.4.5"
   },
   "peerDependencies": {
-    "levelgraph": "~1.1.1"
+    "levelgraph": "^1.1.1"
   },
   "devDependencies": {
     "browserify": "~13.0.0",
@@ -48,7 +48,7 @@
     "istanbul": "~0.4.2",
     "level-test": "~1.7.0",
     "leveldown": "^1.4.4",
-    "levelgraph": "~1.1.1",
+    "levelgraph": "^1.1.1",
     "lodash": "~2.4.1",
     "mocha": "~2.4.5",
     "uglify-js": "~2.6.2",


### PR DESCRIPTION
Due to releasing levelgraph 1.2.0 some days ago the original dependency versioning ~1.1.1 doesn't work any longer if a package.json refers to both projects with the latest versions.
