### PR TITLE
Add preserve option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
+  - "6"
 script:
 - npm run coverage
 - npm run publish-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "4"
   - "5"
   - "6"
+  - "7"
 script:
 - npm run coverage
 - npm run publish-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - "4"
   - "5"
   - "6"
-  - "7"
 script:
 - npm run coverage
 - npm run publish-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ node_js:
   - "7"
 script:
 - npm run coverage
-- npm run publish-coverage
 - test $SAUCE_USERNAME && npm run zuul || echo 'not running on saucelabs'
+after_script:
+- npm run publish-coverage
 env:
   global:
   - secure: HQYn8X9CAc9gtzHdmFErbS5yf2Ug63i/MUAV4jqI/+0v5b6m3zLbhQGSXlboQEk+uqtOebdAdGsTJpoLq1JghqcRdrUwHV+tdENJguc4fStF8q+u9+U8fw8eKiVwSbHKR66Z2uhyabI/AkZ4Lqmlsi7zNM7ESOFRuSyx5c4pUtE=

--- a/README.md
+++ b/README.md
@@ -67,6 +67,31 @@ var levelup = require("levelup"),
     db = levelgraphJSONLD(levelgraph(yourDB));
 ```
 
+`'base'` can also be specified when you create the db:
+```javascript
+var levelup    = require("levelup"),
+    yourDB     = levelup("./yourdb"),
+    levelgraph = require('levelgraph'),
+    jsonld     = require('levelgraph-jsonld'),
+    opts       = { base: 'http://matteocollina.com/base' },
+    db         = jsonld(levelgraph(yourDB), opts);
+```
+
+By default `update`s (and `delete`s) **delete all triples associated to the `@id` of the document before updating it**, the `'preserve'` option will ensure that all `put`s and `delete`s only update the triples that are mentioned in the document:
+
+
+```javascript
+var levelup    = require("levelup"),
+    yourDB     = levelup("./yourdb"),
+    levelgraph = require('levelgraph'),
+    jsonld     = require('levelgraph-jsonld'),
+    opts       = {
+                   base: 'http://matteocollina.com/base',
+                   preserve: true
+                 },
+    db         = jsonld(levelgraph(yourDB), opts);
+```
+
 ### Put
 
 Please keep in mind that LevelGraph-JSONLD __doesn't store the original
@@ -105,15 +130,7 @@ db.jsonld.put(manu, { base: 'http://this/is/an/iri' }, function(err, obj) {
 });
 ```
 
-`'base'` can also be specified when you create the db:
-```javascript
-var levelup    = require("levelup"),
-    yourDB     = levelup("./yourdb"),
-    levelgraph = require('levelgraph'),
-    jsonld     = require('levelgraph-jsonld'),
-    opts       = { base: 'http://matteocollina.com/base' },
-    db         = jsonld(levelgraph(yourDB), opts);
-```
+`'base'` can also be [specified when you create the db](#usage).
 
 __LevelGraph-JSONLD__ also support nested objects, like so:
 ```javascript
@@ -132,6 +149,14 @@ var nested = {
 };
 
 db.jsonld.put(nested, function(err, obj) {
+  // do something...
+});
+```
+
+By default, `put` **deletes all triples associated to the `@id` of the document before updating it**. If you want to instead only update the triples that are part of the document you can use the `{ preserve : true }` option (you can also [set it globally when you create the DB](#usage)):
+
+```javascript
+db.jsonld.put(nested, { preserve : true }, function(err, obj) {
   // do something...
 });
 ```
@@ -166,7 +191,7 @@ var nested = {
 };
 
 db.jsonld.put(nested, function(err, obj) {
-  // obj will be 
+  // obj will be
   // {
   //   "@context": {
   //     "name": "http://xmlns.com/foaf/0.1/name",
@@ -192,6 +217,14 @@ In order to delete an object, you can just pass it's `'@id'` to the
 ```javascript
 db.jsonld.del(manu['@id'], function(err) {
   // do something after it is deleted!
+});
+```
+
+By default, `del` **deletes all triples associated to the `@id`**. If you want to instead only delete the triples that are part of the document, you can use the `{ preserve : true }` option (you can also [set it globally when you create the DB](#usage)):
+
+```javascript
+db.jsonld.del(nested, { preserve : true }, function(err) {
+  // do something...
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -94,25 +94,32 @@ function levelgraphJSONLD(db, jsonldOpts) {
     options.base = options.base || this.options.base;
     options.preserve = options.preserve ||  this.options.preserve || false;
 
-    if (!obj['@id'] && !obj['@graph']) {
-      obj['@id'] = options.base + uuid.v1();
-      options.preserve = true;
-    }
+    jsonld.expand(obj, options, function(err, expanded) {
 
-    if (options.base) {
-      if (obj['@context']) {
-        obj['@context']['@base'] = options.base;
-      } else {
-        obj['@context'] = { '@base' : options.base };
-      }
-    }
+      console.log("put expanded")
+      console.log(expanded)
 
-    graphdb.jsonld.del(obj, options, function(err) {
-      if (err) {
-        return callback && callback(err);
+      if (!expanded['@id'] && !expanded['@graph']) {
+        expanded['@id'] = options.base + uuid.v1();
+        options.preserve = true;
       }
-      doPut(obj, options, callback);
-    });
+
+      if (options.base) {
+        if (expanded['@context']) {
+          expanded['@context']['@base'] = options.base;
+        } else {
+          expanded['@context'] = { '@base' : options.base };
+        }
+      }
+
+      graphdb.jsonld.del(expanded, options, function(err) {
+        if (err) {
+          return callback && callback(err);
+        }
+        doPut(expanded, options, callback);
+      });
+    })
+
   };
 
   graphdb.jsonld.del = function(obj, options, callback) {

--- a/index.js
+++ b/index.js
@@ -107,16 +107,12 @@ function levelgraphJSONLD(db, jsonldOpts) {
       }
     }
 
-    if (options.preserve === true) {
+    graphdb.jsonld.del(obj, options, function(err) {
+      if (err) {
+        return callback && callback(err);
+      }
       doPut(obj, options, callback);
-    } else {
-      graphdb.jsonld.del(obj, options, function(err) {
-        if (err) {
-          return callback && callback(err);
-        }
-        doPut(obj, options, callback);
-      });
-    }
+    });
   };
 
   graphdb.jsonld.del = function(obj, options, callback) {

--- a/index.js
+++ b/index.js
@@ -24,56 +24,64 @@ function levelgraphJSONLD(db, jsonldOpts) {
   function doPut(obj, options, callback) {
     var blanks = {};
 
-    jsonld.toRDF(obj, options, function(err, triples) {
-      if (err || triples.length === 0) {
-        return callback(err, null);
+    jsonld.expand(obj, function(err, expanded) {
+      if (err) {
+        return callback && callback(err);
       }
 
-      var stream = graphdb.putStream();
+      jsonld.toRDF(expanded, options, function(err, triples) {
+        if (err || triples.length === 0) {
+          return callback(err, null);
+        }
 
-      stream.on('error', callback);
-      stream.on('close', function() {
-        callback(null, obj);
-      });
+        var stream = graphdb.putStream();
 
-      triples['@default'].map(function(triple) {
+        stream.on('error', callback);
+        stream.on('close', function() {
+          callback(null, obj);
+        });
 
-        return ['subject', 'predicate', 'object'].reduce(function(acc, key) {
-          var node = triple[key];
-          // generate UUID to identify blank nodes
-          // uses type field set to 'blank node' by jsonld.js toRDF()
-          if (node.type === 'blank node') {
-            if (!blanks[node.value]) {
-              blanks[node.value] = '_:' + uuid.v1();
+        triples['@default'].map(function(triple) {
+
+          return ['subject', 'predicate', 'object'].reduce(function(acc, key) {
+            var node = triple[key];
+            // generate UUID to identify blank nodes
+            // uses type field set to 'blank node' by jsonld.js toRDF()
+            if (node.type === 'blank node') {
+              if (!blanks[node.value]) {
+                blanks[node.value] = '_:' + uuid.v1();
+              }
+              node.value = blanks[node.value];
             }
-            node.value = blanks[node.value];
-          }
-          // preserve object data types using double quotation for literals
-          // and don't keep data type for strings without defined language
-          if(key === 'object' && triple.object.datatype){
-            if(triple.object.datatype.match(XSDTYPE)){
-              if(triple.object.datatype === 'http://www.w3.org/2001/XMLSchema#string'){
-                node.value = '"' + triple.object.value + '"';
+            // preserve object data types using double quotation for literals
+            // and don't keep data type for strings without defined language
+            if(key === 'object' && triple.object.datatype){
+              if(triple.object.datatype.match(XSDTYPE)){
+                if(triple.object.datatype === 'http://www.w3.org/2001/XMLSchema#string'){
+                  node.value = '"' + triple.object.value + '"';
+                } else {
+                  node.value = '"' + triple.object.value + '"^^' + triple.object.datatype;
+                }
+              } else if(triple.object.datatype.match(RDFLANGSTRING)){
+                node.value = '"' + triple.object.value + '"@' + triple.object.language;
               } else {
                 node.value = '"' + triple.object.value + '"^^' + triple.object.datatype;
               }
-            } else if(triple.object.datatype.match(RDFLANGSTRING)){
-              node.value = '"' + triple.object.value + '"@' + triple.object.language;
-            } else {
-              node.value = '"' + triple.object.value + '"^^' + triple.object.datatype;
             }
-          }
-          acc[key] = node.value;
-          return acc;
-        }, {});
-      }).forEach(function(triple) {
-        stream.write(triple);
+            acc[key] = node.value;
+            return acc;
+          }, {});
+        }).forEach(function(triple) {
+          stream.write(triple);
+        });
+        stream.end();
       });
-      stream.end();
+
     });
   }
 
   graphdb.jsonld.put = function(obj, options, callback) {
+
     if (typeof obj === 'string') {
       obj = JSON.parse(obj);
     }
@@ -84,51 +92,126 @@ function levelgraphJSONLD(db, jsonldOpts) {
     }
 
     options.base = options.base || this.options.base;
+    options.preserve = options.preserve || false;
 
-    if (obj['@id']) {
-      graphdb.jsonld.del(obj['@id'], options, function(err) {
+    if (!obj['@id'] && !obj['@graph']) {
+      obj['@id'] = options.base + uuid.v1();
+      options.preserve = true;
+    }
+
+    if (options.base) {
+      if (obj['@context']) {
+        obj['@context']['@base'] = options.base;
+      } else {
+        obj['@context'] = { '@base' : options.base };
+      }
+    }
+
+    if (options.preserve) {
+      doPut(obj, options, callback);
+    } else {
+      graphdb.jsonld.del(obj, options, function(err) {
         if (err) {
           return callback && callback(err);
         }
         doPut(obj, options, callback);
       });
-    } else {
-      obj['@id'] = options.base + uuid.v1();
-      doPut(obj, options, callback);
     }
   };
 
-  graphdb.jsonld.del = function(iri, options, callback) {
+  graphdb.jsonld.del = function(obj, options, callback) {
+    var blanks = {};
+
     if (typeof options === 'function') {
       callback = options;
       options = {};
     }
 
-    if (typeof iri !=='string') {
-      iri = iri['@id'];
-    }
+    options.preserve = options.preserve || false;
 
-    var stream  = graphdb.delStream();
-    stream.on('close', callback);
-    stream.on('error', callback);
 
-    (function delAllTriples(iri, done) {
-      graphdb.get({ subject: iri }, function(err, triples) {
-        async.each(triples, function(triple, cb) {
-          stream.write(triple);
-          if (triple.object.indexOf('_:') === 0) {
-            delAllTriples(triple.object, cb);
-          } else {
-            cb();
-          }
-        }, done);
-      });
-    })(iri, function(err) {
-      if (err) {
-        return callback(err);
+    if (options.preserve === false) {
+      var iri = obj;
+      if (typeof obj !=='string') {
+        iri = obj['@id'];
       }
-      stream.end();
-    });
+
+      var stream = graphdb.delStream();
+      stream.on('close', callback);
+      stream.on('error', callback);
+
+      (function delAllTriples(iri, done) {
+        graphdb.get({ subject: iri }, function(err, triples) {
+          async.each(triples, function(triple, cb) {
+            stream.write(triple);
+            if (triple.object.indexOf('_:') === 0) {
+              delAllTriples(triple.object, cb);
+            } else {
+              cb();
+            }
+          }, done);
+        });
+      })(iri, function(err) {
+        if (err) {
+          return callback(err);
+        }
+        stream.end();
+      });
+    } else {
+      jsonld.expand(obj, function(err, expanded) {
+        if (err) {
+          return callback && callback(err);
+        }
+
+        var stream  = graphdb.delStream();
+        stream.on('close', callback);
+        stream.on('error', callback);
+
+        jsonld.toRDF(expanded, options, function(err, triples) {
+          if (err || triples.length === 0) {
+            return callback(err, null);
+          }
+
+          triples['@default'].map(function(triple) {
+
+            return ['subject', 'predicate', 'object'].reduce(function(acc, key) {
+              var node = triple[key];
+              // mark blank nodes to skip deletion as per https://www.w3.org/TR/ldpatch/#Delete-statement
+              // uses type field set to 'blank node' by jsonld.js toRDF()
+              if (node.type === 'blank node') {
+                if (!blanks[node.value]) {
+                  blanks[node.value] = '_:';
+                }
+                node.value = blanks[node.value];
+              }
+              // preserve object data types using double quotation for literals
+              // and don't keep data type for strings without defined language
+              if(key === 'object' && triple.object.datatype){
+                if(triple.object.datatype.match(XSDTYPE)){
+                  if(triple.object.datatype === 'http://www.w3.org/2001/XMLSchema#string'){
+                    node.value = '"' + triple.object.value + '"';
+                  } else {
+                    node.value = '"' + triple.object.value + '"^^' + triple.object.datatype;
+                  }
+                } else if(triple.object.datatype.match(RDFLANGSTRING)){
+                  node.value = '"' + triple.object.value + '"@' + triple.object.language;
+                } else {
+                  node.value = '"' + triple.object.value + '"^^' + triple.object.datatype;
+                }
+              }
+              acc[key] = node.value;
+              return acc;
+            }, {});
+          }).forEach(function(triple) {
+            // Skip marked blank nodes.
+            if (triple.subject.indexOf('_:') !== 0 && triple.object.indexOf('_:') !== 0) {
+              stream.write(triple);
+            }
+          });
+          stream.end();
+        });
+      })
+    }
   };
 
   // http://json-ld.org/spec/latest/json-ld-api/#data-round-tripping
@@ -238,7 +321,6 @@ function levelgraphJSONLD(db, jsonldOpts) {
       if (err || expanded === null) {
         return callback(err, expanded);
       }
-
       jsonld.compact(expanded[iri], context, options, callback);
     });
   };

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function levelgraphJSONLD(db, jsonldOpts) {
     }
 
     options.base = options.base || this.options.base;
-    options.preserve = options.preserve || false;
+    options.preserve = options.preserve ||  this.options.preserve || false;
 
     if (!obj['@id'] && !obj['@graph']) {
       obj['@id'] = options.base + uuid.v1();
@@ -107,7 +107,7 @@ function levelgraphJSONLD(db, jsonldOpts) {
       }
     }
 
-    if (options.preserve) {
+    if (options.preserve === true) {
       doPut(obj, options, callback);
     } else {
       graphdb.jsonld.del(obj, options, function(err) {
@@ -127,8 +127,7 @@ function levelgraphJSONLD(db, jsonldOpts) {
       options = {};
     }
 
-    options.preserve = options.preserve || false;
-
+    options.preserve = options.preserve ||  this.options.preserve || false;
 
     if (options.preserve === false) {
       var iri = obj;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "levelgraph-jsonld",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "The Object Document Mapper for LevelGraph based on JSON-LD",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "coveralls": "~2.11.8",
     "istanbul": "~0.4.2",
     "leveldown": "^1.5.3",
-    "levelgraph": "iilab/levelgraph#singleton-search",
+    "levelgraph": "^2.0.0",
     "lodash": "^4.17.4",
     "mocha": "^3.2.0",
     "uglify-js": "^2.7.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
-    "levelgraph": "^1.3.1"
+    "levelgraph": "^2.0.0"
   },
   "devDependencies": {
     "browserify": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "coveralls": "~2.11.8",
     "istanbul": "~0.4.2",
     "level-test": "~1.7.0",
-    "leveldown": "^1.4.4",
+    "leveldown": "~1.4.4",
     "levelgraph": "~1.1.1",
     "lodash": "~2.4.1",
     "mocha": "~2.4.5",

--- a/test/del_spec.js
+++ b/test/del_spec.js
@@ -9,7 +9,7 @@ describe('jsonld.del', function() {
     db = helper.getDB({ jsonld: { base: 'http://levelgraph.io/' } });
     manu = helper.getFixture('manu.json');
     tesla = helper.getFixture('tesla.json');
-  }); 
+  });
 
   afterEach(function(done) {
     db.close(done);
@@ -43,6 +43,33 @@ describe('jsonld.del', function() {
     });
   });
 
+  it('should del a complex object with the preserve option leaving blank nodes', function(done) {
+    db.jsonld.put(tesla, function() {
+      db.jsonld.del(tesla, { preserve: true }, function() {
+        db.get({}, function(err, triples) {
+          // blank nodes are left. Consistent with https://www.w3.org/TR/ldpatch/#Delete-statement
+          expect(triples).to.have.length(8);
+          done();
+        });
+      });
+    });
+  });
+
+  it('should del a complex object with the preserve option with no blank nodes completely', function(done) {
+    var library = helper.getFixture('library_framed.json');
+
+    db.jsonld.put(library, function() {
+      db.jsonld.del(library, { preserve: true }, function() {
+        db.get({}, function(err, triples) {
+          // blank nodes are left. Consistent with https://www.w3.org/TR/ldpatch/#Delete-statement
+          expect(triples).to.have.length(0);
+          done();
+        });
+      });
+    });
+  });
+
+
   it('should del an iri', function(done) {
     db.jsonld.put(manu, function() {
       db.jsonld.del(manu['@id'], function() {
@@ -55,10 +82,40 @@ describe('jsonld.del', function() {
     });
   });
 
-  it('should del a single object', function(done) {
+  it('should del a single object leaving blank nodes', function(done) {
     db.jsonld.put(manu, function() {
       db.jsonld.put(tesla, function() {
         db.jsonld.del(tesla, function() {
+          db.get({}, function(err, triples) {
+            // getting the full db
+            expect(triples).to.have.length(2);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  it('should del a single object with the preserve option leaving blank nodes', function(done) {
+    db.jsonld.put(manu, function() {
+      db.jsonld.put(tesla, function() {
+        db.jsonld.del(tesla, { preserve: true }, function() {
+          db.get({}, function(err, triples) {
+            // getting the full db
+            expect(triples).to.have.length(10); // 2 triples from Manu and 8 from tesla blanks.
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  it('should del a single object with the preserve option with no blank nodes completely', function(done) {
+    var library = helper.getFixture('library_framed.json');
+
+    db.jsonld.put(manu, function() {
+      db.jsonld.put(library, function() {
+        db.jsonld.del(library, { preserve: true }, function() {
           db.get({}, function(err, triples) {
             // getting the full db
             expect(triples).to.have.length(2);

--- a/test/get_spec.js
+++ b/test/get_spec.js
@@ -54,7 +54,6 @@ describe('jsonld.get', function() {
 
   it('should support nested objects', function(done) {
     var nested = helper.getFixture('nested.json');
-
     db.jsonld.put(nested, function(err, obj) {
       db.jsonld.get(obj['@id'], { '@context': obj['@context'] }, function(err, result) {
         delete result['knows'][0]['@id'];

--- a/test/helper.js
+++ b/test/helper.js
@@ -221,6 +221,52 @@ var getFixture = function(name) {
         "dc:creator": "Plato",
         "dc:title": "The Republic"
       }
+    },
+    "library.json": {
+      "@context": {
+        "dc": "http://purl.org/dc/elements/1.1/",
+        "ex": "http://example.org/vocab#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "ex:contains": {
+          "@type": "@id"
+        }
+      },
+      "@graph": [
+        {
+          "@id": "http://example.org/library",
+          "@type": "ex:Library",
+          "ex:contains": "http://example.org/library/the-republic"
+        },
+        {
+          "@id": "http://example.org/library/the-republic",
+          "@type": "ex:Book",
+          "dc:creator": "Plato",
+          "dc:title": "The Republic",
+          "ex:contains": "http://example.org/library/the-republic#introduction"
+        },
+        {
+          "@id": "http://example.org/library/the-republic#introduction",
+          "@type": "ex:Chapter",
+          "dc:description": "An introductory chapter on The Republic.",
+          "dc:title": "The Introduction"
+        }
+      ]
+    },
+    "mapped_id.json": {
+      "@context": {
+        "id": "@id",
+        "@vocab": "http://xmlns.com/foaf/0.1/"
+      },
+      "id": "http://bigbluehat.com/#",
+      "name": "BigBlueHat",
+      "knows": [
+
+        {
+          "id": "http://manu.sporny.org#person",
+          "name": "Manu Sporny",
+          "homepage": "http://manu.sporny.org/"
+        }
+      ]
     }
   };
   return fixtures[name];

--- a/test/helper.js
+++ b/test/helper.js
@@ -178,10 +178,26 @@ var getFixture = function(name) {
         "http://dbpedia.org/class/yago/Onomatopoeias" ,
         "http://dbpedia.org/class/yago/Abstraction100002137" ,
         "http://dbpedia.org/class/yago/Device107068844" ,
-        "http://dbpedia.org/class/yago/RhetoricalDevice107098193" 
+        "http://dbpedia.org/class/yago/RhetoricalDevice107098193"
       ]
+    },
+    "chapter.json": {
+      "@context": {
+        "dc": "http://purl.org/dc/elements/1.1/",
+        "ex": "http://example.org/vocab#"
+      },
+      "@id": "http://example.org/library/the-republic#introduction",
+      "@type": "ex:Chapter",
+      "dc:title": "The Introduction"
+    },
+    "chapterdescription.json": {
+      "@context": {
+        "dc": "http://purl.org/dc/elements/1.1/",
+        "ex": "http://example.org/vocab#"
+      },
+      "@id": "http://example.org/library/the-republic#introduction",
+      "dc:description": "An introductory chapter on The Republic."
     }
-
   };
   return fixtures[name];
 };

--- a/test/helper.js
+++ b/test/helper.js
@@ -197,6 +197,30 @@ var getFixture = function(name) {
       },
       "@id": "http://example.org/library/the-republic#introduction",
       "dc:description": "An introductory chapter on The Republic."
+    },
+    "library_framed.json": {
+      "@context": {
+        "dc": "http://purl.org/dc/elements/1.1/",
+        "ex": "http://example.org/vocab#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "ex:contains": {
+          "@type": "@id"
+        }
+      },
+      "@id": "http://example.org/library",
+      "@type": "ex:Library",
+      "ex:contains": {
+        "@id": "http://example.org/library/the-republic",
+        "@type": "ex:Book",
+        "ex:contains": {
+          "@id": "http://example.org/library/the-republic#introduction",
+          "@type": "ex:Chapter",
+          "dc:description": "An introductory chapter on The Republic.",
+          "dc:title": "The Introduction"
+        },
+        "dc:creator": "Plato",
+        "dc:title": "The Republic"
+      }
     }
   };
   return fixtures[name];

--- a/test/put_spec.js
+++ b/test/put_spec.js
@@ -68,7 +68,7 @@ describe('jsonld.put', function() {
   it('should generate an @id for unknown objects', function(done) {
     delete manu['@id'];
     var baseString = 'http://levelgraph.org/tests/';
-    var baseRegEx = /^http:\/\/levelgraph.org\/tests\//;
+    var baseRegEx = /^_\:/;
 
     db.jsonld.put(manu, { base: baseString }, function() {
       db.search({
@@ -81,10 +81,20 @@ describe('jsonld.put', function() {
     });
   });
 
+  it('should generate an @id for all blank nodes in a complex object', function(done) {
+    var tesla = helper.getFixture('tesla.json');
+
+    db.jsonld.put(tesla, function(err, obj) {
+      expect(obj['gr:hasPriceSpecification']['@id']).to.match(/^_\:/);
+      expect(obj['gr:includes']['@id']).to.match(/^_\:/);
+      done();
+    });
+  });
+
   it('should pass the generated @id to callback', function(done) {
     delete manu['@id'];
     var baseString = 'http://levelgraph.org/tests/';
-    var baseRegEx = /^http:\/\/levelgraph.org\/tests\//;
+    var baseRegEx = /^_\:/;
 
     db.jsonld.put(manu, { base: baseString }, function(err, obj) {
       expect(obj['@id']).to.match(baseRegEx);
@@ -199,6 +209,29 @@ describe('jsonld.put', function() {
       done();
     });
   });
+
+  it('should manage mapped @id', function(done) {
+    var mapped_id = helper.getFixture('mapped_id.json')
+    db.jsonld.put(mapped_id, {preserve: true}, function(err, obj) {
+      expect(err && err.name).to.be.null;
+      db.get({}, function(err, triples) {
+        expect(triples).to.have.length(4);
+        done();
+      });
+    });
+  });
+
+  it('should insert graphs', function(done) {
+    var library = helper.getFixture('library.json');
+
+    db.jsonld.put(library, function() {
+      db.get({}, function(err, triples) {
+        expect(triples).to.have.length(9);
+        done();
+      });
+    });
+  });
+
 });
 
 describe('jsonld.put with default base', function() {
@@ -297,6 +330,18 @@ describe('jsonld.put with default base', function() {
       });
     });
   });
+
+  it('should insert graphs', function(done) {
+    var library = helper.getFixture('library.json');
+
+    db.jsonld.put(library, function() {
+      db.get({}, function(err, triples) {
+        expect(triples).to.have.length(9);
+        done();
+      });
+    });
+  });
+
 });
 
 describe('jsonld.put with base and preserve option', function() {
@@ -367,7 +412,7 @@ describe('jsonld.put with base and preserve option', function() {
   it('should generate an @id for unknown objects', function(done) {
     delete manu['@id'];
     var baseString = 'http://levelgraph.org/tests/';
-    var baseRegEx = /^http:\/\/levelgraph.org\/tests\//;
+    var baseRegEx = /^_\:/;
 
     db.jsonld.put(manu, { base: baseString }, function() {
       db.search({
@@ -383,7 +428,7 @@ describe('jsonld.put with base and preserve option', function() {
   it('should pass the generated @id to callback', function(done) {
     delete manu['@id'];
     var baseString = 'http://levelgraph.org/tests/';
-    var baseRegEx = /^http:\/\/levelgraph.org\/tests\//;
+    var baseRegEx = /^_\:/;
 
     db.jsonld.put(manu, { base: baseString }, function(err, obj) {
       expect(obj['@id']).to.match(baseRegEx);
@@ -556,6 +601,17 @@ describe('jsonld.put with base and preserve option', function() {
           expect(triples).to.have.length(3);
           done();
         });
+      });
+    });
+  });
+
+  it('should insert graphs', function(done) {
+    var library = helper.getFixture('library.json');
+
+    db.jsonld.put(library, function() {
+      db.get({}, function(err, triples) {
+        expect(triples).to.have.length(9);
+        done();
       });
     });
   });

--- a/test/put_spec.js
+++ b/test/put_spec.js
@@ -191,7 +191,7 @@ describe('jsonld.put with default base', function() {
   beforeEach(function() {
     db = helper.getDB({ jsonld: { base: 'http://levelgraph.io/ahah/' } });
     manu = helper.getFixture('manu.json');
-  }); 
+  });
 
   afterEach(function(done) {
     db.close(done);
@@ -249,6 +249,20 @@ describe('jsonld.put with default base', function() {
       db.get({}, function(err, triples) {
         expect(triples).to.have.length(5);
         done();
+      });
+    });
+  });
+
+  it('should not overwrite existing facts', function(done) {
+    var chapter = helper.getFixture('chapter.json');
+    var description = helper.getFixture('chapterdescription.json');
+
+    db.jsonld.put(chapter, function() {
+      db.jsonld.put(description, function() {
+        db.get({}, function(err, triples) {
+          expect(triples).to.have.length(3);
+          done();
+        });
       });
     });
   });

--- a/test/put_spec.js
+++ b/test/put_spec.js
@@ -299,7 +299,7 @@ describe('jsonld.put with default base', function() {
   });
 });
 
-describe('jsonld.put with preserve option', function() {
+describe('jsonld.put with base and preserve option', function() {
 
   var db, manu;
 
@@ -310,6 +310,240 @@ describe('jsonld.put with preserve option', function() {
 
   afterEach(function(done) {
     db.close(done);
+  });
+
+
+  it('should accept a done callback', function(done) {
+    db.jsonld.put(manu, done);
+  });
+
+  it('should store a triple', function(done) {
+    db.jsonld.put(manu, function() {
+      db.get({
+        subject: 'http://manu.sporny.org#person',
+        predicate: 'http://xmlns.com/foaf/0.1/name'
+      }, function(err, triples) {
+        expect(triples).to.have.length(1);
+        done();
+      });
+    });
+  });
+
+  it('should store two triples', function(done) {
+    db.jsonld.put(manu, function() {
+      db.get({
+        subject: 'http://manu.sporny.org#person'
+      }, function(err, triples) {
+        expect(triples).to.have.length(2);
+        done();
+      });
+    });
+  });
+
+  it('should store a JSON file', function(done) {
+    db.jsonld.put(JSON.stringify(manu), function() {
+      db.get({
+        subject: 'http://manu.sporny.org#person'
+      }, function(err, triples) {
+        expect(triples).to.have.length(2);
+        done();
+      });
+    });
+  });
+
+  it('should support a base IRI', function(done) {
+    manu['@id'] = '42'
+    db.jsonld.put(manu, { base: 'http://levelgraph.org/tests/' }, function() {
+      db.get({
+        subject: 'http://levelgraph.org/tests/42',
+        predicate: 'http://xmlns.com/foaf/0.1/name'
+      }, function(err, triples) {
+        expect(triples).to.have.length(1);
+        done();
+      });
+    });
+  });
+
+  it('should generate an @id for unknown objects', function(done) {
+    delete manu['@id'];
+    var baseString = 'http://levelgraph.org/tests/';
+    var baseRegEx = /^http:\/\/levelgraph.org\/tests\//;
+
+    db.jsonld.put(manu, { base: baseString }, function() {
+      db.search({
+        subject: db.v('subject'),
+        predicate: 'http://xmlns.com/foaf/0.1/name'
+      }, function(err, solutions) {
+        expect(solutions[0].subject).to.match(baseRegEx);
+        done();
+      });
+    });
+  });
+
+  it('should pass the generated @id to callback', function(done) {
+    delete manu['@id'];
+    var baseString = 'http://levelgraph.org/tests/';
+    var baseRegEx = /^http:\/\/levelgraph.org\/tests\//;
+
+    db.jsonld.put(manu, { base: baseString }, function(err, obj) {
+      expect(obj['@id']).to.match(baseRegEx);
+      done();
+    });
+  });
+
+  it('should convert @type into http://www.w3.org/1999/02/22-rdf-syntax-ns#type', function(done) {
+    db.jsonld.put(helper.getFixture('tesla.json'), function() {
+      db.get({
+        subject: 'http://example.org/cars/for-sale#tesla',
+        predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+        object: 'http://purl.org/goodrelations/v1#Offering'
+      }, function(err, triples) {
+        expect(triples).to.have.length(1);
+        done();
+      });
+    });
+  });
+
+  it('should update a property', function(done) {
+    db.jsonld.put(manu, function(err, instance) {
+      instance.homepage = 'http://another/website';
+      db.jsonld.put(instance, function() {
+        db.get({
+          subject: 'http://manu.sporny.org#person',
+          predicate: 'http://xmlns.com/foaf/0.1/homepage',
+          object: 'http://another/website'
+        }, function(err, triples) {
+          expect(triples).to.have.length(1);
+          done();
+        });
+      });
+    });
+  });
+
+  it('should add a property', function(done) {
+    db.jsonld.put(manu, function(err, instance) {
+      instance.age = 42;
+      instance['@context'].age = 'http://xmlns.com/foaf/0.1/age';
+
+      db.jsonld.put(instance, function() {
+        db.get({
+          subject: 'http://manu.sporny.org#person',
+          predicate: 'http://xmlns.com/foaf/0.1/age',
+          object: '"42"^^http://www.w3.org/2001/XMLSchema#integer'
+        }, function(err, triples) {
+          expect(triples).to.have.length(1);
+          done();
+        });
+      });
+    });
+  });
+
+  it('should delete a property but preserve existing ones', function(done) {
+    db.jsonld.put(manu, function(err, instance) {
+      delete instance.homepage
+
+      db.jsonld.put(instance, function() {
+        db.get({
+          subject: 'http://manu.sporny.org#person',
+          predicate: 'http://xmlns.com/foaf/0.1/homepage'
+        }, function(err, triples) {
+          expect(triples).to.have.length(1);
+          done();
+        });
+      });
+    });
+  });
+
+
+  it('should preserve properties with the preserve option', function(done) {
+    db.jsonld.put(manu, function(err, instance) {
+      delete instance.homepage
+
+      db.jsonld.put(instance, { preserve: true }, function() {
+        db.get({
+          subject: 'http://manu.sporny.org#person',
+          predicate: 'http://xmlns.com/foaf/0.1/homepage'
+        }, function(err, triples) {
+          expect(triples).to.have.length(1);
+          done();
+        });
+      });
+    });
+  });
+
+
+  it('should use the base option', function(done) {
+    manu['@id'] = '42'
+    db.jsonld.put(manu, function() {
+      db.get({
+        subject: 'http://levelgraph.io/ahah/42',
+        predicate: 'http://xmlns.com/foaf/0.1/name'
+      }, function(err, triples) {
+        expect(triples).to.have.length(1);
+        done();
+      });
+    });
+  });
+
+  it('should correctly generate blank nodes as subjects', function(done) {
+    var tesla = helper.getFixture('tesla.json');
+
+    db.jsonld.put(tesla, function() {
+      db.search([{
+        subject: 'http://example.org/cars/for-sale#tesla',
+        predicate: 'http://purl.org/goodrelations/v1#hasPriceSpecification',
+        object: db.v('bnode')
+      }, {
+        subject: db.v('bnode'),
+        predicate: 'http://purl.org/goodrelations/v1#hasCurrency',
+        object: '"USD"'
+      }], function(err, solutions) {
+        expect(solutions[0].bnode).to.exist;
+        done();
+      });
+    });
+  });
+
+  it('should not store undefined objects', function(done) {
+    var tesla = helper.getFixture('tesla.json');
+
+    db.jsonld.put(tesla, function() {
+      db.get({}, function(err, triples) {
+        triples.forEach(function(triple) {
+          expect(triple.object).to.exist;
+        });
+        done();
+      });
+    });
+  });
+
+
+  it('should delete a nested object', function(done) {
+    db.jsonld.put(helper.getFixture('tesla.json'), function(err, instance) {
+      delete instance['gr:hasPriceSpecification'];
+
+      db.jsonld.put(instance, function() {
+        db.get({
+          subject: 'http://example.org/cars/for-sale#tesla',
+          predicate: 'http://purl.org/goodrelations/v1#'
+        }, function(err, triples) {
+          expect(triples).to.be.empty;
+          done();
+        });
+      });
+    });
+  });
+
+  it('should receive error on invalid input', function(done) {
+    var invalid = {
+      "@context": { "@vocab": "http//example.com/" },
+      "test": { "@value": "foo", "bar": "oh yes" }
+    }
+    db.jsonld.put(invalid, function(err) {
+      expect(err && err.name).to.equal('jsonld.SyntaxError');
+      expect(err && err.message).to.equal('Invalid JSON-LD syntax; the value of "@vocab" in a @context must be an absolute IRI.');
+      done();
+    });
   });
 
   it('should not overwrite existing facts', function(done) {

--- a/test/put_spec.js
+++ b/test/put_spec.js
@@ -298,3 +298,32 @@ describe('jsonld.put with default base', function() {
     });
   });
 });
+
+describe('jsonld.put with preserve option', function() {
+
+  var db, manu;
+
+  beforeEach(function() {
+    db = helper.getDB({ jsonld: { base: 'http://levelgraph.io/ahah/', preserve: true } });
+    manu = helper.getFixture('manu.json');
+  });
+
+  afterEach(function(done) {
+    db.close(done);
+  });
+
+  it('should not overwrite existing facts', function(done) {
+    var chapter = helper.getFixture('chapter.json');
+    var description = helper.getFixture('chapterdescription.json');
+
+    db.jsonld.put(chapter, function() {
+      db.jsonld.put(description, function() {
+        db.get({}, function(err, triples) {
+          expect(triples).to.have.length(3);
+          done();
+        });
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
The current behavior of `update` and `delete` is to delete all triples associated to the @id of the document.

This PR tries to maintain backward compatibility and introduce a `preserve` option which helps do targeted updates and deletes such that only the triples mentioned in the updated or deleted documents are modified.

This means that blank nodes are not deleted. It's still possible to delete all nodes (including blank nodes via the previous recursive traversal) associated to a document by not setting the `preserve` option.

Closes #35 